### PR TITLE
gradients upgrade

### DIFF
--- a/defaults/colors/gradients.json
+++ b/defaults/colors/gradients.json
@@ -1,5 +1,27 @@
 {
+  "primary": {
+    "linear": {
+      "type": "linear",
+      "steps": ["#545afb", "#ffff99"],
+      "variants": ["to bottom", "to left", "to right", "to top", "to top left", "to top right", "to bottom left", "to bottom right"]
+    },
+    "accelerate": {
+      "type": "linear",
+      "steps": ["#545afb 0%", "#545afb 75%", "#ffff99 100%"],
+      "variants": ["to bottom", "to left", "to right", "to top"]
+    }
+  },
   "shadow": {
-    "linear": ["rgba(0, 0, 0, 1)", "rgba(0, 0, 0, 0)"]
+    "linear": {
+      "type": "linear",
+      "steps": ["rgba(0, 0, 0, 1)", "rgba(0, 0, 0, 0)"],
+      "variants": ["to bottom", "to left", "to right", "to top"]
+    },
+    "radial": {
+      "type": "radial",
+      "steps": ["rgba(0, 0, 0, .64) 20%", "rgba(0, 0, 0, 0) 100%"],
+      "variants": ["circle"]
+    }
   }
 }
+

--- a/defaults/colors/gradients.process.js
+++ b/defaults/colors/gradients.process.js
@@ -1,37 +1,3 @@
-function setupPlaceholder(namespace, value) {
-
-  const output = {};
-
-  output[`%${namespace}-background`] = {
-    sassdoc: {
-      '@name': `${namespace}-background`
-    },
-    css: {
-      'background-color': `var(--${namespace})`,
-    },
-  };
-
-  output[`%${namespace}-color`] = {
-    sassdoc: {
-      '@name': `${namespace}-color`
-    },
-    css: {
-      'color': `var(--${namespace})`,
-    },
-  };
-
-  output[`%${namespace}-border`] = {
-    sassdoc: {
-      '@name': `${namespace}-border`
-    },
-    css: {
-      'border-color': `var(--${namespace})`,
-    },
-  };
-
-  return output;
-}
-
 exports.default = (prefix, params) => {
 
   // Placeholders
@@ -44,9 +10,12 @@ exports.default = (prefix, params) => {
   for (const[family, gradients] of Object.entries(params)){
 
     // Colors
-    for (const[name, gradientSteps] of Object.entries(gradients)){
+    for (const[name, properties] of Object.entries(gradients)){
 
       const namespace = `${prefix}-${family}-${name}`;
+      const type = properties.type;
+      const gradientSteps = properties.steps;
+      const variants = properties.variants;
 
       const colorsStops = [];
       for (const color of gradientSteps) {
@@ -54,11 +23,9 @@ exports.default = (prefix, params) => {
       }
       const colorStops = colorsStops.join(', ');
 
-      const variants = ['to bottom', 'to left', 'to right', 'to top'];
-
       for(const variant of variants) {
-        const cssProp = `linear-gradient(${variant}, ${colorStops})`;
-        const variantNamespace = `${namespace}-${variant.replace(' ', '-')}`;
+        const cssProp = `${type}-gradient(${variant}, ${colorStops})`;
+        const variantNamespace = `${namespace}-${variant.replace(/ /gi, '-')}`;
         designSystemDirectives.cssVars[variantNamespace] = cssProp;
         designSystemDirectives.sassPlaceholders[`%${variantNamespace}`] = {
           sassdoc: {

--- a/defaults/colors/gradients.twig
+++ b/defaults/colors/gradients.twig
@@ -1,15 +1,16 @@
 <div class="sg-DesignSystemItem">
-  {% for family, types in datas %}
-    <h3>{{ family }}</h3>
-    <div class="sg-MainContent-list--column">
-      {% for name, colors in types %}
-        <div class="sg-Card"
-             style="height: 50px;background-image:linear-gradient(to right, {{ colors|join(',') }});background-size: 25% 100%;">
-          <div>
-            <span>{{ name }}</span>
-          </div>
+    {% for family, types in datas %}
+        <h3>{{ family }}</h3>
+        <div class="sg-MainContent-list--column">
+            {% for name, properties in types %}
+                <div class="sg-Card"
+                     style="min-height: 50px;height: auto;background-image:{{ properties.type }}-gradient({{ properties.type == 'radial' ? 'circle' : 'to right' }}, {{ properties.steps|join(', ') }});background-size: 25% 100%; background-repeat: no-repeat;">
+                    <div>
+                        <span style="flex: 0 0 25%;">{{ name }}</span>
+                        <span style="flex: 1; width: auto;">{{ properties.variants|join(', ') }}<br>{{ properties.steps|join(', ') }}</span>
+                    </div>
+                </div>
+            {% endfor %}
         </div>
-      {% endfor %}
-    </div>
-  {% endfor %}
+    {% endfor %}
 </div>

--- a/defaults/colors/gradients.vue
+++ b/defaults/colors/gradients.vue
@@ -5,10 +5,19 @@
       <template v-for="(types, family) in datas">
         <h3>{{ family }}</h3>
         <div class="sg-MainContent-list--column">
-          <template v-for="(colors, name) in types">
-            <div class="sg-Card" v-bind:style="{height: '50px', 'background-image': 'linear-gradient(to right, '+ colors.join(',') +')', 'background-size': '25% 100%'}">
+          <template v-for="(properties, name) in types">
+            <div
+              class="sg-Card"
+              v-bind:style="{
+                minHeight: '50px',
+                height: 'auto',
+                backgroundImage: properties.type + '-gradient(' + (properties.type == 'radial' ? 'circle' : 'to right' ) + ', ' + properties.steps.join(', ') + ')',
+                backgroundSize: '25% 100%',
+                backgroundRepeat: 'no-repeat'
+              }">
               <div>
-                <span>{{ name }}</span>
+                <span style="flex: 0 0 25%;">{{ name }}</span>
+                <span style="flex: 1; width: auto;">{{ properties.variants.join(', ') }}<br>{{ properties.steps.join(', ') }}</span>
               </div>
             </div>
           </template>


### PR DESCRIPTION
@shepaop voici une MR pour upgrader les gradients,
j'ai eu besoin de gérer les variantes de gradients sur un projet, je l'ai donc gérer en static en surchargeant `gradients.process.js` sur mon projet mais je me suis dit que ça pourrait être utile de les gérer en params pour les prochains projets dans le design-system
j'en ai profité pour supprimer du code mort et prendre compte également le type radial

il reste un léger problème callage en hauteur dans le styleguide mais pour ça il faudrait faire un upgrade dans les repo de framework (drupal/starter_theme_AFW_source, drupal/olema_AFW_source, atomic-framework/framework...).
à dispo pour en discuter si besoin.
Eric